### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+
+rvm:
+  - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,9 @@ language: ruby
 
 rvm:
   - 2.2
+
+services:
+  - postgresql
+
+before_script:
+  - psql -c 'create database carbonsource_test;' -U postgres

--- a/Gemfile
+++ b/Gemfile
@@ -36,8 +36,6 @@ group :development, :test do
   # Capybara runs the headless browser for feature testing
   gem 'capybara'
   # Feature testing framework
-  gem 'cucumber-rails', :require => false
-
   gem 'database_cleaner'
   gem 'rspec-rails', '~> 3.5'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,7 @@ gem 'jbuilder', '~> 2.5'
 
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platform: :mri
+  gem 'rake'
   # Capybara runs the headless browser for feature testing
   gem 'capybara'
   # Feature testing framework
@@ -41,6 +40,8 @@ group :development, :test do
 end
 
 group :development do
+  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'byebug', platform: :mri
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem 'web-console'
   # Deployment/ server automation tool

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,7 @@ DEPENDENCIES
   pg
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
+  rake
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,30 +73,12 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     concurrent-ruby (1.0.2)
-    cucumber (2.4.0)
-      builder (>= 2.1.2)
-      cucumber-core (~> 1.5.0)
-      cucumber-wire (~> 0.0.1)
-      diff-lcs (>= 1.1.3)
-      gherkin (~> 4.0)
-      multi_json (>= 1.7.5, < 2.0)
-      multi_test (>= 0.1.2)
-    cucumber-core (1.5.0)
-      gherkin (~> 4.0)
-    cucumber-rails (1.4.5)
-      capybara (>= 1.1.2, < 3)
-      cucumber (>= 1.3.8, < 4)
-      mime-types (>= 1.16, < 4)
-      nokogiri (~> 1.5)
-      railties (>= 3, < 5.1)
-    cucumber-wire (0.0.1)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.14)
-    gherkin (4.0.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -121,7 +103,6 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.9.1)
     multi_json (1.12.1)
-    multi_test (0.1.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
@@ -229,7 +210,6 @@ DEPENDENCIES
   capistrano-rails
   capybara
   coffee-rails (~> 4.2)
-  cucumber-rails
   database_cleaner
   jbuilder (~> 2.5)
   jquery-rails


### PR DESCRIPTION
Initial travis ci setup. Currently not fully linked, as authorization is still required. Travis has been customised for rails and postgres.

Additionally, cucumber has been removed from the gemfile dependencies (it's a useless feature testing framework).